### PR TITLE
Fix deprecation notice for accessing paths using dot style

### DIFF
--- a/lib/paper_trail_manager.rb
+++ b/lib/paper_trail_manager.rb
@@ -22,8 +22,8 @@ class PaperTrailManager < Rails::Engine
   cattr_accessor :whodunnit_class, :whodunnit_name_method
 
   (Pathname(__FILE__).dirname + '..').tap do |base|
-    paths.app.controllers = base + 'app/controllers'
-    paths.app.views = base + 'app/views'
+    paths["app/controller"] = base + 'app/controllers'
+    paths["app/view"] = base + 'app/views'
   end
 
   def self._allow_set(action, block)


### PR DESCRIPTION
Accessing paths using dot style as in `config.paths.app.controller` is deprecated. Please use `config.paths["app/controller"]` style instead.
