### PR TITLE
Allow configuration of ChangeController parent class, layout, and route helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 [![Build Status](https://secure.travis-ci.org/fusion94/paper_trail_manager.png)](http://travis-ci.org/fusion94/paper_trail_manager)
 
-PaperTrailManager
-================
+# PaperTrailManager
 
 Browse, subscribe, view and revert changes to records when using Ruby on Rails 3 and the `paper_trail` gem.
 
 This software has been in use for a year at http://calagator.org and http://epdx.org. It works well. It has reasonable tests. However, it could definitely use more work.
 
-Installation
-------------
+## Installation
 
-If you have a Ruby on Rails 3 application where you're using the `paper_trail` gem to track changes to your records, you can make use of this like:
+If you have a Ruby on Rails 3 or 4 application where you're using the `paper_trail` gem to track changes to your records, you can make use of this like:
 
 Add the following line to your `Gemfile`:
     gem 'paper_trail_manager'
@@ -27,8 +25,35 @@ Restart the server and go to the `/changes` URI to browse, subscribe, view and r
 
     http://localhost:3000/changes
 
-Development
------------
+### Configuration
+
+Several aspects of PaperTrailManager may be optionally configured
+by creating an initializer in your application 
+(e.g. `config/initializers/paper_trail_manager.rb`).
+
+To specify when reverts are allowed:
+
+    PaperTrailManager.allow_revert_when do |controller, version|
+      controller.current_user and controller.current_user.admin?
+    end
+
+To specify how to look up users/memebers/etc specified in Paper Trail's 'whodunnit' column:
+
+    PaperTrailManager.whodunnit_class = User
+    PaperTrailManager.whodunnit_name_method = :nicename   # defaults to :name
+
+When including PaperTrailManager within another Rails engine, you may need to
+override PaperTrailManager::ChangesController's parent class to reference the
+engine's ApplicationController configure it to use your engine's url helpers:
+
+    PaperTrailManager.base_controller = "MyEngine::ApplicationController"
+    PaperTrailManager.route_helpers = MyEngine::Engine.routes.url_helpers
+
+You can also specify the layout:
+
+    PaperTrailManager.layout = 'my_engine/application'
+
+## Development
 
 Setup:
 
@@ -50,12 +75,10 @@ Adding support for new Rails versions:
 * Fix whatever breaks.
 * Please contribute your fixes with a Github pull request.
 
-License
--------
+## License
 
 This program is provided under an MIT open source license, read the [LICENSE.txt](http://github.com/igal/paper_trail_manager/blob/master/LICENSE.txt) file for details.
 
-To Note:
---------
+## To Note:
 
 This project was originally devloped by [Igal Koshevoy](http://github.com/igal). Unfortunately @igal passed away on April 9th, 2013 and I took over the project afterwords.

--- a/app/controllers/paper_trail_manager/changes_controller.rb
+++ b/app/controllers/paper_trail_manager/changes_controller.rb
@@ -1,6 +1,12 @@
-class PaperTrailManager::ChangesController < ApplicationController
+PaperTrailManager::ChangesController = Class.new(PaperTrailManager.base_controller.constantize)
+
+class PaperTrailManager::ChangesController
   # Default number of changes to list on a pagenated index page.
   PER_PAGE = 50
+
+  helper PaperTrailManager.route_helpers if PaperTrailManager.route_helpers
+  helper PaperTrailManager::ChangesHelper
+  layout PaperTrailManager.layout if PaperTrailManager.layout
 
   # List changes
   def index

--- a/app/controllers/paper_trail_manager/changes_controller.rb
+++ b/app/controllers/paper_trail_manager/changes_controller.rb
@@ -1,3 +1,4 @@
+# Allow the parent class of ChangesController to be configured in the host app
 PaperTrailManager::ChangesController = Class.new(PaperTrailManager.base_controller.constantize)
 
 class PaperTrailManager::ChangesController

--- a/lib/paper_trail_manager.rb
+++ b/lib/paper_trail_manager.rb
@@ -2,22 +2,6 @@ require 'rails'
 require 'paper_trail'
 require 'will_paginate'
 
-# = PaperTrailManager
-#
-# == Example usage
-#
-# To specify when reverts are allowed, write an initializer similar to this:
-#
-#   # config/initializers/paper_trail_manager.rb
-#   PaperTrailManager.allow_revert_when do |controller, version|
-#     controller.current_user and controller.current_user.admin?
-#   end
-#
-#   To specify how to look up users/memebers/etc specified in Paper Trail's 'whodunnit' column:
-#
-#   PaperTrailManager.whodunnit_class = User
-#   PaperTrailManager.whodunnit_name_method = :nicename   # defaults to :name
-#
 class PaperTrailManager < Rails::Engine
   @@whodunnit_name_method = :name
   cattr_accessor :whodunnit_class, :whodunnit_name_method, :route_helpers, :layout, :base_controller

--- a/lib/paper_trail_manager.rb
+++ b/lib/paper_trail_manager.rb
@@ -20,7 +20,9 @@ require 'will_paginate'
 #
 class PaperTrailManager < Rails::Engine
   @@whodunnit_name_method = :name
-  cattr_accessor :whodunnit_class, :whodunnit_name_method
+  cattr_accessor :whodunnit_class, :whodunnit_name_method, :route_helpers, :layout, :base_controller
+
+  self.base_controller = "ApplicationController"
 
   (Pathname(__FILE__).dirname + '..').tap do |base|
     paths["app/controller"] = base + 'app/controllers'


### PR DESCRIPTION
When PaperTrailManager is included within another Rails engine, the root level `ApplicationController` does not include the needed `chanegs_path` route and is not a suitable parent class for `PaperTrailManager::ChangeController`. These changes allow optional configuration of `ChangeController`'s base class, as well as explicit configuration of which route helper module and layout to use.

This came to light when deploying Calagator's codebase after converting it to be distributed as a Rails engine and are documented in https://github.com/calagator/calagator/issues/400.