### PR TITLE
allow not linking to a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ To specify how to look up users/memebers/etc specified in Paper Trail's 'whodunn
     PaperTrailManager.whodunnit_class = User
     PaperTrailManager.whodunnit_name_method = :nicename   # defaults to :name
 
+And for linking (or not) to the user with a custom path helper:
+
+    PaperTrailManager.user_path_method = :admin_path # defaults to :user_path
+    PaperTrailManager.user_path_method = nil # no "show user" page in app
+
 When including PaperTrailManager within another Rails engine, you may need to
 override PaperTrailManager::ChangesController's parent class to reference the
 engine's ApplicationController configure it to use your engine's url helpers:

--- a/app/views/paper_trail_manager/changes/_version.html.erb
+++ b/app/views/paper_trail_manager/changes/_version.html.erb
@@ -12,7 +12,13 @@
       <%= change_item_link(version) %>
       <% if PaperTrailManager.whodunnit_class && version.whodunnit %>
         <% if user = PaperTrailManager.whodunnit_class.find(version.whodunnit) rescue nil %>
-          by <%= link_to(h(user.send(PaperTrailManager.whodunnit_name_method)), user_path(user)) %>
+          <% if PaperTrailManager.user_path_method && user %>
+            by <%= link_to(h(user.send(PaperTrailManager.whodunnit_name_method)), send(:user_path_method, user)) %>
+          <% else %>
+            by <%= h(user.send(PaperTrailManager.whodunnit_name_method)) %>
+          <% end %>
+        <% else %>
+          by <%= version.whodunnit %>
         <% end %>
       <% end %>
       <% if change_revert_allowed?(version) %>

--- a/lib/paper_trail_manager.rb
+++ b/lib/paper_trail_manager.rb
@@ -19,9 +19,10 @@ class PaperTrailManager < Rails::Engine
   end
 
   @@whodunnit_name_method = :name
-  cattr_accessor :whodunnit_class, :whodunnit_name_method, :route_helpers, :layout, :base_controller
+  cattr_accessor :whodunnit_class, :whodunnit_name_method, :route_helpers, :layout, :base_controller, :user_path_method
 
   self.base_controller = "ApplicationController"
+  self.user_path_method = :user_path
 
   (Pathname(__FILE__).dirname + '..').tap do |base|
     paths["app/controller"] = base + 'app/controllers'


### PR DESCRIPTION
Not all apps have a path helper for their User model.
or their User model is named something else.

This allows you to specify what path helper to use, or to use none.
From the Readme:

    PaperTrailManager.user_path_method = :admin_path # defaults to :user_path
    PaperTrailManager.user_path_method = nil # no "show user" page in app