### PR TITLE
Simplify changes_for

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -7,12 +7,14 @@ RAILS_VERSIONS.each do |rails_version|
       gem "rails", "~> #{rails_version}"
       gem "paper_trail", "~> #{paper_trail_version}"
       gem "will_paginate", "~> 3.0"
+      gem "test-unit", "~> 3.0" if rails_version == "3.2.0"
     end
 
     appraise "rails-#{rails_version}-paper_trail-#{paper_trail_version}-kaminari" do
       gem "rails", "~> #{rails_version}"
       gem "paper_trail", "~> #{paper_trail_version}"
       gem "kaminari", "~> 0.16"
+      gem "test-unit", "~> 3.0" if rails_version == "3.2.0"
     end
   end
 end

--- a/app/helpers/paper_trail_manager/changes_helper.rb
+++ b/app/helpers/paper_trail_manager/changes_helper.rb
@@ -25,16 +25,16 @@ class PaperTrailManager
     #     ...
     #   }
     def changes_for(version)
-      return {} unless version.changeset.present?
-
       case version.event
       when "create", "update"
+        return {} unless version.changeset
         version.changeset.inject({}) do |changes, (attr, (prev, curr))|
           changes.store(attr, {previous: prev, current: curr}) && changes
         end
       when "destroy"
-        version.changeset.inject({}) do |changes, (attr, (curr, prev))|
-          changes.store(attr, {previous: prev, current: curr}) && changes
+        return {} unless version.reify
+        version.reify.attributes.reject{|k,v| v.nil?}.inject({}) do |changes, (attr, value)|
+          changes.store(attr, {previous: value, current: nil}) && changes
         end
       else
         raise ArgumentError, "Unknown event: #{version.event}"

--- a/app/helpers/paper_trail_manager/changes_helper.rb
+++ b/app/helpers/paper_trail_manager/changes_helper.rb
@@ -32,8 +32,9 @@ class PaperTrailManager
           changes.store(attr, {previous: prev, current: curr}) && changes
         end
       when "destroy"
-        return {} unless version.reify
-        version.reify.attributes.reject{|k,v| v.nil?}.inject({}) do |changes, (attr, value)|
+        record = version_reify(version)
+        return {} unless record
+        record.attributes.reject{|k,v| v.nil?}.inject({}) do |changes, (attr, value)|
           changes.store(attr, {previous: value, current: nil}) && changes
         end
       else
@@ -71,6 +72,12 @@ class PaperTrailManager
       else
         return content_tag(:span, change_title_for(version), :class => 'change_item')
       end
+    end
+
+    def version_reify(version)
+      version.reify
+    rescue ArgumentError
+      nil
     end
   end
 end

--- a/app/helpers/paper_trail_manager/changes_helper.rb
+++ b/app/helpers/paper_trail_manager/changes_helper.rb
@@ -25,6 +25,7 @@ class PaperTrailManager
     #     ...
     #   }
     def changes_for(version)
+      return {} unless version.changeset
       case version.event
       when "create", "update"
         version.changeset.inject({}) do |changes, (attr, (prev, curr))|

--- a/app/helpers/paper_trail_manager/changes_helper.rb
+++ b/app/helpers/paper_trail_manager/changes_helper.rb
@@ -25,7 +25,8 @@ class PaperTrailManager
     #     ...
     #   }
     def changes_for(version)
-      return {} unless version.changeset
+      return {} unless version.changeset.present?
+
       case version.event
       when "create", "update"
         version.changeset.inject({}) do |changes, (attr, (prev, curr))|

--- a/gemfiles/rails_3.2.0_paper_trail_3.0_kaminari.gemfile
+++ b/gemfiles/rails_3.2.0_paper_trail_3.0_kaminari.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "rails", "~> 3.2.0"
 gem "paper_trail", "~> 3.0"
 gem "kaminari", "~> 0.16"
+gem "test-unit", "~> 3.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_3.2.0_paper_trail_3.0_will_paginate.gemfile
+++ b/gemfiles/rails_3.2.0_paper_trail_3.0_will_paginate.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "rails", "~> 3.2.0"
 gem "paper_trail", "~> 3.0"
 gem "will_paginate", "~> 3.0"
+gem "test-unit", "~> 3.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_3.2.0_paper_trail_4.0_kaminari.gemfile
+++ b/gemfiles/rails_3.2.0_paper_trail_4.0_kaminari.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "rails", "~> 3.2.0"
 gem "paper_trail", "~> 4.0"
 gem "kaminari", "~> 0.16"
+gem "test-unit", "~> 3.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_3.2.0_paper_trail_4.0_will_paginate.gemfile
+++ b/gemfiles/rails_3.2.0_paper_trail_4.0_will_paginate.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "rails", "~> 3.2.0"
 gem "paper_trail", "~> 4.0"
 gem "will_paginate", "~> 3.0"
+gem "test-unit", "~> 3.0"
 
 gemspec :path => "../"

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -4,6 +4,6 @@
         gem "sqlite3-ruby", :require => "sqlite3"
         gem "rake"
         gem "will_paginate", "~> 3.0.pre2"
-        gem "paper_trail_manager", :path => "/home/micah/work/paper_trail_manager"
+        gem "paper_trail_manager", :path => __FILE__ + "/../../../"
         gem 'factory_girl_rails', '~> 1.7.0'
         gem 'rspec-rails', '~> 2.11.0'


### PR DESCRIPTION
This should not affect public functionality.

The necessary info for changes for can be discerned from the version itself.