### PR TITLE
Simplify change_title_for

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Restart the server and go to the `/changes` URI to browse, subscribe, view and r
 ### Configuration
 
 Several aspects of PaperTrailManager may be optionally configured
-by creating an initializer in your application 
+by creating an initializer in your application
 (e.g. `config/initializers/paper_trail_manager.rb`).
 
 To specify when reverts are allowed:
@@ -48,6 +48,10 @@ To specify how to look up users/memebers/etc specified in Paper Trail's 'whodunn
 
     PaperTrailManager.whodunnit_class = User
     PaperTrailManager.whodunnit_name_method = :nicename   # defaults to :name
+
+To specify a method to call to identify an item on an index page:
+
+    PaperTrailManager.item_name_method = :nicename
 
 And for linking (or not) to the user with a custom path helper:
 

--- a/app/helpers/paper_trail_manager/changes_helper.rb
+++ b/app/helpers/paper_trail_manager/changes_helper.rb
@@ -44,17 +44,11 @@ class PaperTrailManager
 
     # Returns string title for the versioned record.
     def change_title_for(version)
-      current = version.next.try(:reify)
-      previous = version.reify rescue nil
-      record = version.item_type.constantize.find(version.item_id) rescue nil
-
-      name = nil
-      [:name, :title, :to_s].each do |name_method|
-        [previous, current, record].each do |obj|
-          name = obj.send(name_method) if obj.respond_to?(name_method)
-          break if name
-        end
-        break if name
+      if PaperTrailManager.item_name_method
+        record = version_reify(version) || version.next.try(:reify) || version.item
+        name = record.send(PaperTrailManager.item_name_method)
+      else
+        name = "#{version.item_type} #{version.item_id}"
       end
 
       return h(name)

--- a/app/views/paper_trail_manager/changes/_version.html.erb
+++ b/app/views/paper_trail_manager/changes/_version.html.erb
@@ -7,8 +7,6 @@
   <td class='change_details'>
     <p class='change_details_description'>
       <strong class='event'><%= version.event %></strong>
-      <span class='item_type'><%= version.item_type %></span>
-      <span class='item_id'><%= version.item_id %></span>
       <%= change_item_link(version) %>
       <% if PaperTrailManager.whodunnit_class && version.whodunnit %>
         <% if user = PaperTrailManager.whodunnit_class.find(version.whodunnit) rescue nil %>

--- a/lib/paper_trail_manager.rb
+++ b/lib/paper_trail_manager.rb
@@ -20,7 +20,7 @@ class PaperTrailManager < Rails::Engine
 
   @@whodunnit_name_method = :name
   cattr_accessor :whodunnit_class, :whodunnit_name_method, :route_helpers,
-    :layout, :base_controller, :user_path_method
+    :layout, :base_controller, :user_path_method, :item_name_method
 
   self.base_controller = "ApplicationController"
   self.user_path_method = :user_path


### PR DESCRIPTION
This PR requires to be merged first https://github.com/fusion94/paper_trail_manager/pull/27

Instead of guessing what the title method is, we should just ask
explicitly in a config option.

The new default ended up duplicating text on the version partial, so I
deleted the non-link text.

Combined with PR #27, this cut index page load time for an item with 9 versions from ~275ms down to ~140ms.