### PR TITLE
Prep for 0.7.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Changes to `paper_trail_manager`
 ================================
 
+* 0.7.0
+    * Add support for Rails 5 and 6
+    * Add support for paper_trail 5.x – 10.x
+    * Drop support for Rails < 4.1
+    * Drop support for Ruby < 2.5
+
 * 0.6.0
     * Add support for linking changes to user records via `PaperTrailManager.whodunnit_name_method` and `PaperTrailManager.user_path_method`
     * Add new `PaperTrailManager.item_name_method` configuration option

--- a/paper_trail_manager.gemspec
+++ b/paper_trail_manager.gemspec
@@ -5,11 +5,11 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'paper_trail_manager'
-  spec.version       = '0.6.0'
+  spec.version       = '0.7.0'
   spec.authors       = ['Igal Koshevoy', 'Reid Beels']
   spec.authors       = ['mail@reidbeels.com']
-  spec.summary       = 'A user interface for `paper_trail` versioning data in Ruby on Rails 3 applications.'
-  spec.description   = 'Browse, subscribe, view and revert changes to records when using Ruby on Rails 3 and the `paper_trail` gem.'
+  spec.summary       = 'A user interface for `paper_trail` versioning data in Rails applications.'
+  spec.description   = 'Browse, subscribe, view and revert changes to records when using Rails and the `paper_trail` gem.'
   spec.homepage      = 'https://github.com/fusion94/paper_trail_manager'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
Preparations for 0.7.0 release:

    * Add support for Rails 5 and 6
    * Add support for paper_trail 5.x – 10.x
    * Drop support for Rails < 4.1
    * Drop support for Ruby < 2.5