### PR TITLE
Fix Rails 7.x deprecations and breaking changes

### DIFF
--- a/app/helpers/paper_trail_manager/changes_helper.rb
+++ b/app/helpers/paper_trail_manager/changes_helper.rb
@@ -59,9 +59,9 @@ class PaperTrailManager
     end
 
     def change_item_types
-      ActiveRecord::Base.subclasses.select do |klass|
+      ActiveRecord::Base.descendants.select do |klass|
         klass.include?(PaperTrail::Model::InstanceMethods)
-      end.map(&:to_s)
+      end.map(&:to_s).sort
     end
 
     # Returns HTML link for the item stored in the version, e.g. a link to a Company record stored in the version.

--- a/app/views/paper_trail_manager/changes/_version.html.erb
+++ b/app/views/paper_trail_manager/changes/_version.html.erb
@@ -20,7 +20,7 @@
         <% end %>
       <% end %>
       <% if change_revert_allowed?(version) %>
-        <%= link_to 'Roll back', change_path(version), :method => 'put', :class => 'rollback', :data => { :confirm => 'Are you sure?' } %>
+        <%= button_to 'Roll back', change_path(version), method: :put, class: 'rollback', form: { data: { turbo_confirm: 'Are you sure?' } } %>
       <% end %>
     </p>
     <% if version.event == 'update' or version.event == 'create' %>

--- a/app/views/paper_trail_manager/changes/index.html.erb
+++ b/app/views/paper_trail_manager/changes/index.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   Show:
-  <%= ([link_to('All', changes_path)] + change_item_types.map { |type| link_to(type.pluralize, changes_path(:type => type)) }).join(' | ').html_safe %>
+  <%= ([link_to('All', changes_path)] + change_item_types.map { |type| link_to(type.pluralize, changes_path(type: type)) }).join(' | ').html_safe %>
 </p>
 <div class="table-responsive">
   <table class='changes_table table table-bordered'>
@@ -23,7 +23,7 @@
       <% if @versions.any? %>
         <% @versions.each do |version| %>
           <% next unless change_show_allowed?(version) %>
-          <%= render :partial => 'version', :object => version %>
+          <%= render partial: 'version', object: version %>
         <% end %>
       <% else %>
         <td rowspan='2'> &mdash; No changes found &mdash; </td>
@@ -31,4 +31,3 @@
     </tbody>
   </table>
 </div>
-

--- a/app/views/paper_trail_manager/changes/show.html.erb
+++ b/app/views/paper_trail_manager/changes/show.html.erb
@@ -4,7 +4,6 @@
   <tr class='changes_header'>
     <th class='change_time'>Time</th>
     <th class='change_details'>Attribute with previous and current values</th>
-    <%= render :partial => 'version', :object => @version %>
+    <%= render partial: 'version', object: @version %>
   </tr>
 </table>
-


### PR DESCRIPTION
## Summary
Address deprecated APIs and breaking changes for Rails 7.0/7.1 and paper_trail 12+/15+ compatibility.

## Changes
- **`link_to method: :put` → `button_to method: :put`** — Rails 7 with Turbo doesn't support `link_to` with HTTP methods. `button_to` generates a proper form.
- **`data: { confirm: ... }` → `data: { turbo_confirm: ... }`** — Rails 7/Turbo uses `data-turbo-confirm` instead of `data-confirm`.
- **`ActiveRecord::Base.subclasses` → `.descendants`** — In Rails 7.1, `subclasses` returns only direct subclasses, missing STI models. `descendants` traverses the full hierarchy.
- **Hash rocket → keyword syntax** — Modernized all view hash syntax (`:partial =>` → `partial:`, etc.).

## Test Plan
- Rollback button renders as a form with PUT method
- Turbo confirmation dialog works on rollback
- All versioned model types appear in the type filter dropdown
- Views render without deprecation warnings under Rails 7.1

Closes #53