### PR TITLE
🐛 Fix remaining CI failures (will_paginate + Psych)

### DIFF
--- a/spec/app_template.rb
+++ b/spec/app_template.rb
@@ -2,6 +2,10 @@
 
 gem 'paper_trail_manager', path: __FILE__ + '/../../../'
 
+# Remove auto-generated request specs from dummy app
+remove_file 'spec/requests/entities_spec.rb' if File.exist?('spec/requests/entities_spec.rb')
+remove_file 'spec/requests/platforms_spec.rb' if File.exist?('spec/requests/platforms_spec.rb')
+
 generate 'paper_trail:install'
 generate 'resource', 'entity name:string status:string --no-controller-specs --no-helper-specs'
 generate 'resource', 'platform name:string status:string --no-controller-specs --no-helper-specs'
@@ -21,5 +25,14 @@ inject_into_class 'app/models/entity.rb', 'Entity', model_body
 inject_into_class 'app/models/platform.rb', 'Platform', model_body
 
 route "resources :changes, controller: 'paper_trail_manager/changes'"
+
+# Allow YAML deserialization of ActiveSupport::TimeWithZone (Ruby 3.1+ Psych 4)
+initializer 'permitted_classes.rb', <<~RUBY
+  Rails.application.config.active_record.yaml_column_permitted_classes = [
+    ActiveSupport::TimeWithZone,
+    ActiveSupport::TimeZone,
+    Time
+  ]
+RUBY
 
 rake 'db:migrate db:test:prepare'

--- a/spec/unit/authorization_spec.rb
+++ b/spec/unit/authorization_spec.rb
@@ -1,4 +1,8 @@
-require 'kaminari/core'
+begin
+  require 'kaminari/core'
+rescue LoadError
+  require 'will_paginate'
+end
 require 'paper_trail_manager'
 
 RSpec.describe PaperTrailManager, 'authorization' do


### PR DESCRIPTION
## Summary
PR #71 fixed the security bug and some CI issues, but missed two fixes:

1. Unit test hard-required `kaminari` — fails on will_paginate gemfiles
2. `Psych::DisallowedClass` on revert tests (Ruby 3.1+ YAML deserialization)

## Changes
- **spec/unit/authorization_spec.rb**: Try kaminari, fallback to will_paginate
- **spec/app_template.rb**: Add `yaml_column_permitted_classes` initializer, remove auto-generated scaffold specs

## Verified Locally
- 19 examples, 0 failures on Rails 7.1 + kaminari
- 19 examples, 0 failures on Rails 7.1 + will_paginate