### PR TITLE
🐛 Fix gemspec authors/email and use PER_PAGE constant

### DIFF
--- a/app/controllers/paper_trail_manager/changes_controller.rb
+++ b/app/controllers/paper_trail_manager/changes_controller.rb
@@ -28,7 +28,7 @@ class PaperTrailManager
       @page = nil if @page.zero?
 
       @per_page = params[:per_page].to_i
-      @per_page = nil if @per_page.zero?
+      @per_page = PER_PAGE if @per_page.zero?
 
       @versions = if defined?(WillPaginate)
                     @versions.paginate(page: @page, per_page: @per_page)

--- a/paper_trail_manager.gemspec
+++ b/paper_trail_manager.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'paper_trail_manager'
   spec.version       = '0.8.0'
   spec.authors       = ['Igal Koshevoy', 'Reid Beels']
-  spec.authors       = ['mail@reidbeels.com']
+  spec.email         = ['mail@reidbeels.com']
   spec.summary       = 'A user interface for `paper_trail` versioning data in Rails applications.'
   spec.description   = 'Browse, subscribe, view and revert changes to records when using Rails and the `paper_trail` gem.'
   spec.homepage      = 'https://github.com/DamageLabs/paper_trail_manager'


### PR DESCRIPTION
## Summary
Two quick bug fixes.

## Changes
- **paper_trail_manager.gemspec**: Second `spec.authors` → `spec.email` (#60)
- **changes_controller.rb**: Use `PER_PAGE` constant as default instead of nil (#61)

## Test Plan
- [x] `gem build` shows correct authors and email
- [x] Index page defaults to 50 items per page when param not provided

Closes #60
Closes #61