### PR TITLE
🐛 Fix broken HTML structure in show and index views

### DIFF
--- a/app/views/paper_trail_manager/changes/index.html.erb
+++ b/app/views/paper_trail_manager/changes/index.html.erb
@@ -26,7 +26,9 @@
           <%= render partial: 'version', object: version %>
         <% end %>
       <% else %>
-        <td rowspan='2'> &mdash; No changes found &mdash; </td>
+        <tr>
+          <td colspan='2'> &mdash; No changes found &mdash; </td>
+        </tr>
       <% end %>
     </tbody>
   </table>

--- a/app/views/paper_trail_manager/changes/show.html.erb
+++ b/app/views/paper_trail_manager/changes/show.html.erb
@@ -1,9 +1,13 @@
 <h1>Change <%= @version.id %></h1>
 
 <table class='changes_table'>
-  <tr class='changes_header'>
-    <th class='change_time'>Time</th>
-    <th class='change_details'>Attribute with previous and current values</th>
+  <thead>
+    <tr class='changes_header'>
+      <th class='change_time'>Time</th>
+      <th class='change_details'>Attribute with previous and current values</th>
+    </tr>
+  </thead>
+  <tbody>
     <%= render partial: 'version', object: @version %>
-  </tr>
+  </tbody>
 </table>


### PR DESCRIPTION
## Summary
Two HTML structure bugs in the views.

## Changes
- **show.html.erb**: Version partial moved out of header `<tr>` into separate `<tbody>`. Added `<thead>`/`<tbody>` structure.
- **index.html.erb**: Empty state `<td>` wrapped in `<tr>`, `rowspan` → `colspan`

## Test Plan
- [x] 19 examples, 0 failures (Rails 7.1 + kaminari)
- [x] Show page renders valid HTML
- [x] Empty index renders valid HTML

Closes #62