### PR TITLE
✨ Add Rails install generator

### DIFF
--- a/lib/generators/paper_trail_manager/install/install_generator.rb
+++ b/lib/generators/paper_trail_manager/install/install_generator.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails/generators'
+
+class PaperTrailManager
+  class InstallGenerator < Rails::Generators::Base
+    source_root File.expand_path('templates', __dir__)
+    desc 'Install PaperTrailManager: add route and create initializer'
+
+    def add_route
+      route_string = "resources :changes, controller: 'paper_trail_manager/changes'"
+      routes_file = File.join(destination_root, 'config/routes.rb')
+
+      if File.exist?(routes_file) && File.read(routes_file).include?(route_string)
+        say_status :skip, 'Route already exists', :yellow
+      else
+        route route_string
+      end
+    end
+
+    def create_initializer
+      template 'initializer.rb', 'config/initializers/paper_trail_manager.rb'
+    end
+
+    def show_post_install
+      say ''
+      say '✅ PaperTrailManager installed!', :green
+      say ''
+      say 'Next steps:'
+      say '  1. Restart your Rails server'
+      say '  2. Visit /changes to browse your PaperTrail version history'
+      say '  3. Edit config/initializers/paper_trail_manager.rb to customize authorization'
+      say ''
+    end
+  end
+end

--- a/lib/generators/paper_trail_manager/install/templates/initializer.rb
+++ b/lib/generators/paper_trail_manager/install/templates/initializer.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# PaperTrailManager configuration
+# See: https://github.com/DamageLabs/paper_trail_manager
+
+# Control who can view the changes index.
+# PaperTrailManager.allow_index_when do |controller|
+#   controller.current_user.present?
+# end
+
+# Control who can view individual change details.
+# Defaults to the allow_index rules if not set separately.
+# PaperTrailManager.allow_show_when do |controller, version|
+#   controller.current_user.present?
+# end
+
+# Control who can revert changes.
+# PaperTrailManager.allow_revert_when do |controller, version|
+#   controller.current_user&.admin?
+# end
+
+# Configure how to look up users referenced in PaperTrail's whodunnit column.
+# PaperTrailManager.whodunnit_class = User
+# PaperTrailManager.whodunnit_name_method = :name
+
+# Specify a method to identify items on the index page.
+# PaperTrailManager.item_name_method = :name
+
+# Customize the user path helper (set to nil to disable user links).
+# PaperTrailManager.user_path_method = :user_path
+
+# When embedding inside another Rails engine:
+# PaperTrailManager.base_controller = 'MyEngine::ApplicationController'
+# PaperTrailManager.route_helpers = MyEngine::Engine.routes.url_helpers
+# PaperTrailManager.layout = 'my_engine/application'


### PR DESCRIPTION
## Summary
`rails generate paper_trail_manager:install` — one command to set up routes and initializer.

## Changes
- **lib/generators/paper_trail_manager/install/install_generator.rb**: Generator class
- **lib/generators/paper_trail_manager/install/templates/initializer.rb**: Commented config template

## Features
- Adds route (skips if exists)
- Creates initializer with all config options documented
- Idempotent (safe to re-run)
- Post-install instructions

## Tested
- Fresh install: route + initializer created
- Re-run: route skipped, initializer marked identical
- 50 examples, 0 failures

Closes #68