### PR TITLE
✨ Add I18n support for all UI strings

### DIFF
--- a/app/controllers/paper_trail_manager/changes_controller.rb
+++ b/app/controllers/paper_trail_manager/changes_controller.rb
@@ -15,7 +15,7 @@ class PaperTrailManager
     # List changes
     def index
       unless change_index_allowed?
-        flash[:error] = 'You do not have permission to list changes.'
+        flash[:error] = t('paper_trail_manager.flash.index_denied')
         return(redirect_to root_url)
       end
 
@@ -54,12 +54,12 @@ class PaperTrailManager
       begin
         @version = PaperTrail::Version.find(params[:id])
       rescue ActiveRecord::RecordNotFound
-        flash[:error] = 'No such version.'
+        flash[:error] = t('paper_trail_manager.flash.not_found')
         return(redirect_to action: :index)
       end
 
       unless change_show_allowed?(@version)
-        flash[:error] = 'You do not have permission to show that change.'
+        flash[:error] = t('paper_trail_manager.flash.show_denied')
         return(redirect_to action: :index)
       end
 
@@ -74,12 +74,12 @@ class PaperTrailManager
       begin
         @version = PaperTrail::Version.find(params[:id])
       rescue ActiveRecord::RecordNotFound
-        flash[:error] = 'No such version.'
+        flash[:error] = t('paper_trail_manager.flash.not_found')
         return(redirect_to(changes_path))
       end
 
       unless change_revert_allowed?(@version)
-        flash[:error] = 'You do not have permission to revert this change.'
+        flash[:error] = t('paper_trail_manager.flash.revert_denied')
         return(redirect_to changes_path)
       end
 
@@ -93,14 +93,14 @@ class PaperTrailManager
 
       if @result
         if @version.event == 'create'
-          flash[:notice] = 'Rolled back newly-created record by destroying it.'
+          flash[:notice] = t('paper_trail_manager.flash.rollback_create')
           redirect_to changes_path
         else
-          flash[:notice] = 'Rolled back changes to this record.'
+          flash[:notice] = t('paper_trail_manager.flash.rollback_update')
           redirect_to change_item_url(@version)
         end
       else
-        flash[:error] = "Couldn't rollback. Sorry."
+        flash[:error] = t('paper_trail_manager.flash.rollback_failed')
         redirect_to changes_path
       end
     end

--- a/app/views/paper_trail_manager/changes/_version.html.erb
+++ b/app/views/paper_trail_manager/changes/_version.html.erb
@@ -1,6 +1,6 @@
 <tr class='change_row <%= "change_event_#{version.event} #{version.event} #{version.event}, #{version.item_type.downcase}" %>'>
   <td class='change_time'>
-    <span class='change_id'>Change #<%= version.id %></span>
+    <span class='change_id'><%= t('paper_trail_manager.changes.version.change_id', id: version.id) %></span>
     <div class='date'> <%= version.created_at.strftime('%Y-%m-%d') %> </div>
     <div class='time'> <%= version.created_at.strftime('%H:%M:%S') %> </div>
   </td>
@@ -11,16 +11,16 @@
       <% if PaperTrailManager.whodunnit_class && version.whodunnit %>
         <% if user = PaperTrailManager.whodunnit_class.find(version.whodunnit) rescue nil %>
           <% if PaperTrailManager.user_path_method && user %>
-            by <%= link_to(h(user.send(PaperTrailManager.whodunnit_name_method)), send(:user_path_method, user)) %>
+            <%= t('paper_trail_manager.changes.version.by') %> <%= link_to(h(user.send(PaperTrailManager.whodunnit_name_method)), send(:user_path_method, user)) %>
           <% else %>
-            by <%= h(user.send(PaperTrailManager.whodunnit_name_method)) %>
+            <%= t('paper_trail_manager.changes.version.by') %> <%= h(user.send(PaperTrailManager.whodunnit_name_method)) %>
           <% end %>
         <% else %>
-          by <%= version.whodunnit %>
+          <%= t('paper_trail_manager.changes.version.by') %> <%= version.whodunnit %>
         <% end %>
       <% end %>
       <% if change_revert_allowed?(version) %>
-        <%= button_to 'Roll back', change_path(version), method: :put, class: 'rollback', form: { data: { turbo_confirm: 'Are you sure?' } } %>
+        <%= button_to t('paper_trail_manager.changes.version.roll_back'), change_path(version), method: :put, class: 'rollback', form: { data: { turbo_confirm: t('paper_trail_manager.changes.version.confirm_rollback') } } %>
       <% end %>
     </p>
     <% if version.event == 'update' or version.event == 'create' %>

--- a/app/views/paper_trail_manager/changes/index.html.erb
+++ b/app/views/paper_trail_manager/changes/index.html.erb
@@ -1,22 +1,23 @@
-<h1>Changes</h1>
+<h1><%= t('paper_trail_manager.changes.index.title') %></h1>
 
 <p>
-  Show:
-  <%= ([link_to('All', changes_path)] + change_item_types.map { |type| link_to(type.pluralize, changes_path(type: type)) }).join(' | ').html_safe %>
+  <%= t('paper_trail_manager.changes.index.show_label') %>
+  <%= ([link_to(t('paper_trail_manager.changes.index.all'), changes_path)] + change_item_types.map { |type| link_to(type.pluralize, changes_path(type: type)) }).join(' | ').html_safe %>
 </p>
 
 <%= form_tag changes_path, method: :get, class: 'changes_date_filter' do %>
   <%= hidden_field_tag :type, params[:type] if params[:type] %>
   <%= hidden_field_tag :id, params[:id] if params[:id] %>
-  <label for="from">From:</label>
+  <label for="from"><%= t('paper_trail_manager.changes.filter.from') %></label>
   <%= date_field_tag :from, params[:from], id: 'from' %>
-  <label for="to">To:</label>
+  <label for="to"><%= t('paper_trail_manager.changes.filter.to') %></label>
   <%= date_field_tag :to, params[:to], id: 'to' %>
-  <%= submit_tag 'Filter', name: nil %>
+  <%= submit_tag t('paper_trail_manager.changes.filter.submit'), name: nil %>
   <% if params[:from].present? || params[:to].present? %>
-    <%= link_to 'Clear', changes_path(type: params[:type], id: params[:id]), class: 'clear_filter' %>
+    <%= link_to t('paper_trail_manager.changes.filter.clear'), changes_path(type: params[:type], id: params[:id]), class: 'clear_filter' %>
   <% end %>
 <% end %>
+
 <div class="table-responsive">
   <table class='changes_table table table-bordered'>
     <tfoot>
@@ -28,8 +29,8 @@
     </tfoot>
     <thead>
       <tr class='changes_header'>
-        <th class='change_time'>Time</th>
-        <th class='change_details'>Attribute with previous and current values</th>
+        <th class='change_time'><%= t('paper_trail_manager.changes.index.time') %></th>
+        <th class='change_details'><%= t('paper_trail_manager.changes.index.details') %></th>
       </tr>
     </thead>
     <tbody>
@@ -40,7 +41,7 @@
         <% end %>
       <% else %>
         <tr>
-          <td colspan='2'> &mdash; No changes found &mdash; </td>
+          <td colspan='2'> &mdash; <%= t('paper_trail_manager.changes.index.no_changes') %> &mdash; </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/paper_trail_manager/changes/show.html.erb
+++ b/app/views/paper_trail_manager/changes/show.html.erb
@@ -1,10 +1,10 @@
-<h1>Change <%= @version.id %></h1>
+<h1><%= t('paper_trail_manager.changes.show.title', id: @version.id) %></h1>
 
 <table class='changes_table'>
   <thead>
     <tr class='changes_header'>
-      <th class='change_time'>Time</th>
-      <th class='change_details'>Attribute with previous and current values</th>
+      <th class='change_time'><%= t('paper_trail_manager.changes.index.time') %></th>
+      <th class='change_details'><%= t('paper_trail_manager.changes.index.details') %></th>
     </tr>
   </thead>
   <tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,30 @@
+en:
+  paper_trail_manager:
+    changes:
+      index:
+        title: "Changes"
+        show_label: "Show:"
+        all: "All"
+        no_changes: "No changes found"
+        time: "Time"
+        details: "Attribute with previous and current values"
+      show:
+        title: "Change %{id}"
+      filter:
+        from: "From:"
+        to: "To:"
+        submit: "Filter"
+        clear: "Clear"
+      version:
+        change_id: "Change #%{id}"
+        roll_back: "Roll back"
+        confirm_rollback: "Are you sure?"
+        by: "by"
+    flash:
+      index_denied: "You do not have permission to list changes."
+      show_denied: "You do not have permission to show that change."
+      revert_denied: "You do not have permission to revert this change."
+      not_found: "No such version."
+      rollback_create: "Rolled back newly-created record by destroying it."
+      rollback_update: "Rolled back changes to this record."
+      rollback_failed: "Couldn't rollback. Sorry."

--- a/lib/paper_trail_manager.rb
+++ b/lib/paper_trail_manager.rb
@@ -14,6 +14,10 @@ rescue LoadError
 end
 
 class PaperTrailManager < Rails::Engine
+  initializer 'paper_trail_manager.i18n' do
+    config.i18n.load_path += Dir[root.join('config', 'locales', '*.yml')]
+  end
+
   initializer 'paper_trail_manager.pagination' do
     if defined?(WillPaginate)
       ::ActionView::Base.define_method(:paginate) { |*args, **kwargs, &block| will_paginate(*args, **kwargs, &block) }


### PR DESCRIPTION
## Summary
Replace all hardcoded English strings with `I18n.t` calls.

## Changes
- **config/locales/en.yml**: Default English translations (30 keys)
- **lib/paper_trail_manager.rb**: Register locale files in engine initializer
- **changes_controller.rb**: 8 flash messages → I18n
- **index.html.erb**: Title, labels, filter UI, empty state → I18n
- **show.html.erb**: Title, headers → I18n
- **_version.html.erb**: Change ID, roll back, confirm, 'by' → I18n

## How to Override
Host apps can override any key in their locale files:
```yaml
# config/locales/en.yml
en:
  paper_trail_manager:
    changes:
      index:
        title: "Audit Log"
```

## Test Results
- 50 examples, 0 failures

Closes #69