### PR TITLE
✨ Ship default stylesheet for changes views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ mkmf.log
 spec/dummy
 Gemfile.lock
 gemfiles/*.lock
+*.gem

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ resources :changes, controller: 'paper_trail_manager/changes'
 
 Restart your server and visit `/changes` to browse, view, and revert your changes.
 
+### Stylesheet (optional)
+
+A default stylesheet is included. Add to your layout or application CSS:
+
+```erb
+<%= stylesheet_link_tag 'paper_trail_manager/changes' %>
+```
+
+Or require it in `app/assets/stylesheets/application.css`:
+
+```css
+/*= require paper_trail_manager/changes */
+```
+
+The styles are low-specificity and easy to override in your own stylesheet.
+
 ## Configuration
 
 Create an initializer (e.g. `config/initializers/paper_trail_manager.rb`) to customize behavior.

--- a/app/assets/stylesheets/paper_trail_manager/changes.css
+++ b/app/assets/stylesheets/paper_trail_manager/changes.css
@@ -1,0 +1,256 @@
+/*
+ * PaperTrailManager — Default Stylesheet
+ *
+ * Include in your layout:
+ *   <%= stylesheet_link_tag 'paper_trail_manager/changes' %>
+ *
+ * Or import in your application.css:
+ *   *= require paper_trail_manager/changes
+ *
+ * Override any styles in your own stylesheet — these are intentionally
+ * low-specificity so your app's styles take precedence.
+ */
+
+/* ── Table ────────────────────────────────────────────────── */
+
+.changes_table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.changes_table thead {
+  border-bottom: 2px solid #dee2e6;
+}
+
+.changes_table th {
+  padding: 10px 12px;
+  text-align: left;
+  font-weight: 600;
+  color: #495057;
+  background-color: #f8f9fa;
+}
+
+.changes_table td {
+  padding: 10px 12px;
+  vertical-align: top;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.changes_table tfoot td {
+  padding: 12px;
+  border-bottom: none;
+}
+
+/* ── Change Row ───────────────────────────────────────────── */
+
+.change_row {
+  transition: background-color 0.15s ease;
+}
+
+.change_row:hover {
+  background-color: #f8f9fa;
+}
+
+/* Event-specific row colors */
+.change_event_create {
+  border-left: 3px solid #28a745;
+}
+
+.change_event_update {
+  border-left: 3px solid #007bff;
+}
+
+.change_event_destroy {
+  border-left: 3px solid #dc3545;
+}
+
+/* ── Time Column ──────────────────────────────────────────── */
+
+.change_time {
+  width: 140px;
+  white-space: nowrap;
+}
+
+.change_id {
+  display: block;
+  font-size: 12px;
+  color: #868e96;
+  margin-bottom: 2px;
+}
+
+.change_time .date {
+  font-weight: 500;
+  color: #343a40;
+}
+
+.change_time .time {
+  font-size: 13px;
+  color: #868e96;
+}
+
+/* ── Details Column ───────────────────────────────────────── */
+
+.change_details_description {
+  margin: 0 0 8px 0;
+}
+
+.change_details_description .event {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-right: 4px;
+}
+
+.change_event_create .event {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.change_event_update .event {
+  background-color: #cce5ff;
+  color: #004085;
+}
+
+.change_event_destroy .event {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+
+.change_item {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.change_item:hover {
+  text-decoration: underline;
+}
+
+/* ── Diff Table ───────────────────────────────────────────── */
+
+.change_details_table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin-top: 6px;
+  background-color: #f8f9fa;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.change_details_table td {
+  padding: 4px 8px;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.change_detail_key {
+  font-weight: 500;
+  color: #495057;
+  width: 20%;
+  white-space: nowrap;
+}
+
+.change_detail_value.previous {
+  color: #dc3545;
+  background-color: #fff5f5;
+  word-break: break-word;
+}
+
+.change_detail_value.current {
+  color: #28a745;
+  background-color: #f0fff4;
+  word-break: break-word;
+}
+
+.change_detail_spacer {
+  text-align: center;
+  width: 30px;
+  color: #868e96;
+}
+
+.change_details_table .even {
+  background-color: #f8f9fa;
+}
+
+.change_details_table .odd {
+  background-color: #ffffff;
+}
+
+/* ── Rollback Button ──────────────────────────────────────── */
+
+.rollback {
+  display: inline-block;
+  padding: 3px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #856404;
+  background-color: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 3px;
+  cursor: pointer;
+  margin-left: 8px;
+  transition: background-color 0.15s ease;
+}
+
+.rollback:hover {
+  background-color: #ffc107;
+  color: #533f03;
+}
+
+/* ── Date Filter Form ─────────────────────────────────────── */
+
+.changes_date_filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.changes_date_filter label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #495057;
+}
+
+.changes_date_filter input[type="date"] {
+  padding: 4px 8px;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.changes_date_filter input[type="submit"] {
+  padding: 4px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  background-color: #007bff;
+  border: 1px solid #007bff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.changes_date_filter input[type="submit"]:hover {
+  background-color: #0056b3;
+}
+
+.clear_filter {
+  font-size: 13px;
+  color: #868e96;
+}
+
+/* ── Empty State ──────────────────────────────────────────── */
+
+.changes_table tbody td[colspan] {
+  text-align: center;
+  color: #868e96;
+  padding: 24px;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
Default CSS stylesheet so the changes UI looks decent out of the box.

## Changes
- **app/assets/stylesheets/paper_trail_manager/changes.css**: Full stylesheet (~160 lines)
- **README.md**: Include instructions (stylesheet_link_tag or require)

## Styles Include
- Table layout with hover states
- Event-specific colors: green (create), blue (update), red (destroy)
- Diff highlighting: red (previous) → green (current)
- Rollback button styling
- Date filter form layout
- Empty state
- Low-specificity selectors — easy to override

## Test Results
- 50 examples, 0 failures

Closes #70